### PR TITLE
Better logic for expedition selection

### DIFF
--- a/src/CardContext.js
+++ b/src/CardContext.js
@@ -4,13 +4,20 @@ import { EXPEDITIONS } from "./cards";
 // Create the context. Empty function allows us to call setState
 export const CardContext = React.createContext([{}, () => {}]);
 
-const CardContextProvider = (props) => {
-  const randomExpedition = EXPEDITIONS[Math.floor(Math.random() * EXPEDITIONS.length)];
+export const newExpeditionDeck = () => {
+  let shuffled = EXPEDITIONS
+  .map((a) => ({sort: Math.random(), value: a}))
+  .sort((a, b) => a.sort - b.sort)
+  .map((a) => a.value)
+  return shuffled;
+}
 
+const CardContextProvider = (props) => {
   const [state, setState] = useState({
-    currentExpedition: randomExpedition,
+    expeditionDeck: newExpeditionDeck(),
     currentRound: 1,
   });
+  
   return (
     <CardContext.Provider value={[state, setState]}>
       {props.children}

--- a/src/Expedition.js
+++ b/src/Expedition.js
@@ -6,10 +6,10 @@ export default function Expedition() {
 
   function handleRoundChange() {
     if (state.currentRound < 7) {
-      setState(state => ({ ...state, currentRound: state.currentRound + 1 }));;
+      setState(state => ({ ...state, currentRound: state.currentRound + 1 }));
     } else {
-      setState(state => ({ ...state, expeditionDeck: newExpeditionDeck() }));;
-      setState(state => ({ ...state, currentRound: 1 }));;
+      // generate new expedition deck and reset round to 1
+      setState(state => ({ ...state, currentRound: 1, expeditionDeck: newExpeditionDeck() }));
     }
   }
 

--- a/src/Expedition.js
+++ b/src/Expedition.js
@@ -1,16 +1,14 @@
 import React, { useContext } from "react";
-import { CardContext } from "./CardContext";
-import { EXPEDITIONS } from "./cards";
+import { CardContext, newExpeditionDeck } from "./CardContext";
 
 export default function Expedition() {
   const [state, setState] = useContext(CardContext);
 
   function handleRoundChange() {
-    const randomExpedition = EXPEDITIONS[Math.floor(Math.random() * EXPEDITIONS.length)];
-    setState(state => ({ ...state, currentExpedition: randomExpedition }));
     if (state.currentRound < 7) {
       setState(state => ({ ...state, currentRound: state.currentRound + 1 }));;
     } else {
+      setState(state => ({ ...state, expeditionDeck: newExpeditionDeck() }));;
       setState(state => ({ ...state, currentRound: 1 }));;
     }
   }
@@ -21,8 +19,8 @@ export default function Expedition() {
         <div>
           Expedition card #{state.currentRound}/7
         </div>
-        Current expedition card: <b>{state.currentExpedition.name}</b>
-        {state.currentExpedition.rawShape.map((item,i) => (
+        Current expedition card: <b>{state.expeditionDeck[state.currentRound].name}</b>
+        {state.expeditionDeck[state.currentRound].rawShape.map((item,i) => (
           <div key={i}>{item}</div>
         ))}
       </div>

--- a/src/cards.js
+++ b/src/cards.js
@@ -1,31 +1,66 @@
 // To do; add all eight expedition cards
 export const EXPEDITIONS = [
   {
+    name: "Square",
+    id: "S",
+    rawShape: [
+      ["x","x"],
+      ["x","x"]
+    ]
+  },
+  {
     name: "Uppercase L",
     id: "L",
-    validate: null,
     rawShape: [
       ["x","x","x"],
       ["x","",""]
     ]
   },
   {
+    name: "Tetris",
+    id: "T",
+    rawShape: [
+      [" ","x"," "],
+      ["x","x","x"]
+    ]
+  },
+  {
     name: "Long I",
     id: "I",
-    validate: null,
     rawShape: [
       ["x","x","x"]
     ]
   },
   {
-    name: "Square",
-    id: "S",
-    validate: null,
+    name: "Long I",
+    id: "I",
     rawShape: [
-      ["x","x"],
-      ["x","x"]
+      ["x","x","x"]
     ]
   },
+  {
+    name: "Bend",
+    id: "B",
+    rawShape: [
+      ["x","x"],
+      ["x",""]
+    ]
+  },
+  {
+    name: "Bend",
+    id: "B",
+    rawShape: [
+      ["x","x"],
+      ["x",""]
+    ]
+  },
+  {
+    name: "Dash",
+    id: "D",
+    rawShape: [
+      ["x","x"]
+    ]
+  }
 ]
 
 // To do; add all 47 treasure cards


### PR DESCRIPTION
## Summary
Previously, expeditions were chosen randomly from the `EXPEDITIONS` array. This means that any expedition could appear any number of times during each round. This PR improves the expedition selection logic to match gameplay:

Initialization: The `EXPEDITIONS` array is randomized and saved to `state.expeditionDeck`.
During play: Each round increases `state.currentRound`. When `state.currentRound` is `7`, the `newExpeditionDeck()` method generates a new Expedition deck, which is saved to state, and `state.currentRound` is reset to one. This ensures that 7 (random) of 8 expedition cards will appear each round.

All expedition cards have also been added to the game.

## Testing
Spin it up and click "next expedition card" a bunch of times. You should see a new pattern of cards each time the round resets to one.